### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cabal: ["3.2"]
+        cabal: ["3.6"]
         # no ghc-7.6.3 or ghc-7.8.4 available
         ghc:
           - "7.0.4"
@@ -26,6 +26,8 @@ jobs:
           - "8.6.5"
           - "8.8.4"
           - "8.10.7"
+          - "9.0.1"
+          - "9.2.1"
     steps:
       - uses: actions/checkout@v2
       - uses: haskell/actions/setup@v1.2.7
@@ -49,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cabal: ["3.2"]
+        cabal: ["3.6"]
         # haskell/actions/setup does not recognise ghc-7.0.4, -7.2.2 or -7.4.2
         # choco install ghc --version 7.10.3 is broken
         ghc:
@@ -62,6 +64,14 @@ jobs:
           - "8.6.5"
           - "8.8.4"
           - "8.10.7"
+        winio: [false]
+        include:
+          - ghc: "9.0.1"
+            cabal: "3.6"
+            winio: true
+          - ghc: "9.2.1"
+            cabal: "3.6"
+            winio: true
     steps:
       - uses: actions/checkout@v2
       - uses: haskell/actions/setup@v1.2.7
@@ -80,3 +90,5 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ matrix.ghc }}-
       - run: cabal v2-build
+      - if: matrix.winio
+        run: cabal v2-build --ghc-option=-with-rtsopts=--io-manager=native


### PR DESCRIPTION
Add GHC 9.0.1 and 9.2.1. Update cabal to 3.6.

For `windows-latest`, introduce `winio` boolean flag in the `matrix`, to indicate whether the script should build also with `--ghc-option=-with-rtsopts=--io-manager=native`.