### PR TITLE
Refine `setTitle`

### DIFF
--- a/src/System/Console/ANSI/Codes.hs
+++ b/src/System/Console/ANSI/Codes.hs
@@ -59,6 +59,7 @@ module System.Console.ANSI.Codes
   , colorToCode, csi, sgrToCode
   ) where
 
+import Data.Char (isPrint)
 import Data.List (intercalate)
 
 import Data.Colour.SRGB (toSRGB24, RGB (..))
@@ -258,4 +259,4 @@ hyperlinkWithIdCode linkId = hyperlinkWithParamsCode [("id", linkId)]
 -- behaviour between Unixes and Windows.
 setTitleCode :: String -- ^ New window title and icon name
              -> String
-setTitleCode title = "\ESC]0;" ++ filter (/= '\007') title ++ "\007"
+setTitleCode title = "\ESC]0;" ++ filter isPrint title ++ "\ESC\\"

--- a/src/System/Console/ANSI/Windows/Emulator.hs
+++ b/src/System/Console/ANSI/Windows/Emulator.hs
@@ -10,6 +10,7 @@ import Control.Exception (catchJust, IOException)
 import qualified Control.Exception as CE (catch)
 import Control.Monad (unless)
 import Data.Bits ((.&.), (.|.), complement, shiftL, shiftR)
+import Data.Char (isPrint)
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
 import Data.List (foldl', minimumBy)
 import Data.Maybe (mapMaybe)
@@ -357,7 +358,7 @@ hHyperlinkWithParams h _ _ = hPutStr h
 -- really what I'm designing for.
 hSetTitle h title
   = emulatorFallback (Unix.hSetTitle h title) $
-      withTString title $ setConsoleTitle
+      withTString (filter isPrint title) setConsoleTitle
 
 cursorPositionRef :: IORef (Map.Map HANDLE COORD)
 {-# NOINLINE cursorPositionRef #-}


### PR DESCRIPTION
Uses the recommended STRING TERMINATOR (ST) of `\ESC\\`, rather than the legacy `\BEL` (`\007`). See https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h3-Operating-System-Commands.

Filters the title of all non-printable characters, not just `\BEL`.

Applies the same filter to the title in the Windows emulation.