### PR TITLE
Fix #120 Add reportLayerColor, getReportedLayerColor, getLayerColor

### DIFF
--- a/app/Example.hs
+++ b/app/Example.hs
@@ -27,6 +27,7 @@ examples = [ cursorMovementExample
            , titleExample
            , getCursorPositionExample
            , getTerminalSizeExample
+           , getLayerColorExample
            ]
 
 main :: IO ()
@@ -439,3 +440,16 @@ getTerminalSizeExample = do
     Nothing -> putStrLn "Error: unable to get the terminal size\n"
   pause
   -- The size of the terminal is 25 rows by 80 columns.
+
+getLayerColorExample :: IO ()
+getLayerColorExample = do
+  fgResult <- getLayerColor Foreground
+  case fgResult of
+    Just fgCol -> putStrLn $ "The reported foreground color is:\n" ++
+      show fgCol ++ "\n"
+    Nothing -> putStrLn "Error: unable to get the foreground color\n"
+  bgResult <- getLayerColor Background
+  case bgResult of
+    Just bgCol -> putStrLn $ "The reported background color is:\n" ++
+      show bgCol ++ "\n"
+    Nothing -> putStrLn "Error: unable to get the background color\n"

--- a/src/System/Console/ANSI/Codes.hs
+++ b/src/System/Console/ANSI/Codes.hs
@@ -56,6 +56,9 @@ module System.Console.ANSI.Codes
     -- * Using screen buffers
   , useAlternateScreenBufferCode, useNormalScreenBufferCode
 
+    -- * Reporting background or foreground colors
+  , reportLayerColorCode
+
     -- * Select Graphic Rendition mode: colors and other whizzy stuff
   , setSGRCode
 
@@ -200,6 +203,25 @@ restoreCursorCode = "\ESC8"
 -- @since 0.7.1
 reportCursorPositionCode :: String
 reportCursorPositionCode = csi [] "6n"
+
+-- | Code to emit the layer color into the console input stream, immediately
+-- after being recognised on the output stream, as:
+-- @ESC ] \<Ps> ; rgb: \<red> ; \<green> ; \<blue> \<ST>@
+-- where @\<Ps>@ is @10@ for 'Foreground' and @11@ for 'Background'; @\<red>@,
+-- @\<green>@ and @\<blue>@ are the color channel values in hexadecimal (4, 8,
+-- 12 and 16 bit values are possible, although 16 bit values are most common);
+-- and @\<ST>@ is the STRING TERMINATOR (ST). ST depends on the terminal
+-- software and may be the @BEL@ character or @ESC \\@ characters.
+--
+-- This function may be of limited, or no, use on Windows operating systems
+-- because (1) the control character sequence is not supported on native
+-- terminals (2) of difficulties in obtaining the data emitted into the
+-- console input stream. See 'System.Console.ANSI.getReportedLayerColor'.
+--
+-- @since 0.11.4
+reportLayerColorCode :: ConsoleLayer -> String
+reportLayerColorCode Foreground = osc "10" "?"
+reportLayerColorCode Background = osc "11" "?"
 
 clearFromCursorToScreenEndCode, clearFromCursorToScreenBeginningCode,
   clearScreenCode :: String

--- a/src/System/Console/ANSI/Windows.hs
+++ b/src/System/Console/ANSI/Windows.hs
@@ -11,7 +11,6 @@ module System.Console.ANSI.Windows
 
 import System.IO (Handle)
 
-import System.Console.ANSI.Types
 import qualified System.Console.ANSI.Unix as U
 import System.Console.ANSI.Windows.Detect (ANSISupport (..),
   ConsoleDefaultState (..), aNSISupport)
@@ -159,6 +158,13 @@ useNormalScreenBufferCode :: String
 useNormalScreenBufferCode = nativeOrEmulated
   U.useNormalScreenBufferCode E.useNormalScreenBufferCode
 
+-- * Reporting the background or foreground colors
+hReportLayerColor = E.hReportLayerColor
+
+reportLayerColorCode :: ConsoleLayer -> String
+reportLayerColorCode = nativeOrEmulated
+  U.reportLayerColorCode E.reportLayerColorCode
+
 -- * Select Graphic Rendition mode: colors and other whizzy stuff
 --
 -- The following SGR codes are NOT implemented by Windows 10 Threshold 2:
@@ -234,3 +240,11 @@ getReportedCursorPosition = E.getReportedCursorPosition
 -- hGetCursorPosition :: Handle -> IO (Maybe (Int, Int))
 -- (See Common-Include.hs for Haddock documentation)
 hGetCursorPosition = E.hGetCursorPosition
+
+-- getReportedLayerColor :: ConsoleLayer -> IO String
+-- (See Common-Include.hs for Haddock documentation)
+getReportedLayerColor = E.getReportedLayerColor
+
+-- hGetLayerColor :: ConsoleLayer -> IO (Maybe (RGB Word16))
+-- (See Common-Include.hs for Haddock documentation)
+hGetLayerColor = E.hGetLayerColor

--- a/src/System/Console/ANSI/Windows/Emulator.hs
+++ b/src/System/Console/ANSI/Windows/Emulator.hs
@@ -402,25 +402,7 @@ hReportLayerColor h layer
       \handle -> do
         result <- getConsoleScreenBufferInfoEx handle
         let attributes = csbix_attributes result
-            ct = csbix_color_table result
-            colorTable = map (\f -> f ct)
-              [ ct_color0
-              , ct_color1
-              , ct_color2
-              , ct_color3
-              , ct_color4
-              , ct_color5
-              , ct_color6
-              , ct_color7
-              , ct_color8
-              , ct_color9
-              , ct_colorA
-              , ct_colorB
-              , ct_colorC
-              , ct_colorD
-              , ct_colorE
-              , ct_colorF
-              ]
+            colorTable = csbix_color_table result
             fgRef = attributes .&. fOREGROUND_INTENSE_WHITE
             bgRef = shiftR (attributes .&. bACKGROUND_INTENSE_WHITE) 4
             fgColor = colorTable !! fromIntegral fgRef

--- a/src/System/Console/ANSI/Windows/Emulator/Codes.hs
+++ b/src/System/Console/ANSI/Windows/Emulator/Codes.hs
@@ -26,6 +26,9 @@ module System.Console.ANSI.Windows.Emulator.Codes
     -- * Using screen buffers
   , useAlternateScreenBufferCode, useNormalScreenBufferCode
 
+    -- * Reporting background and foreground colors
+  , reportLayerColorCode
+
     -- * Select Graphic Rendition mode: colors and other whizzy stuff
   , setSGRCode
 
@@ -88,6 +91,9 @@ scrollPageDownCode _ = ""
 useAlternateScreenBufferCode, useNormalScreenBufferCode :: String
 useAlternateScreenBufferCode = ""
 useNormalScreenBufferCode      = ""
+
+reportLayerColorCode :: ConsoleLayer -> String
+reportLayerColorCode _ = ""
 
 setSGRCode :: [SGR] -- ^ Commands: these will typically be applied on top of the
                     -- current console SGR mode. An empty list of commands is

--- a/src/System/Win32/Compat.hs
+++ b/src/System/Win32/Compat.hs
@@ -27,6 +27,7 @@ module System.Win32.Compat
   , SHORT                -- from Win32-2.5.0.0
   , TCHAR
   , UINT
+  , ULONG                -- from Win32-2.5.0.0
   , WORD
   , failIfFalse_
   , getLastError
@@ -53,7 +54,7 @@ import System.Win32.Types (BOOL, DWORD, ErrCode, HANDLE, LPCTSTR, LPDWORD,
 
 #if !defined(PATCHING_WIN32_PACKAGE)
 
-import System.Win32.Types (SHORT, withHandleToHANDLE)
+import System.Win32.Types (SHORT, ULONG, withHandleToHANDLE)
 
 #else
 
@@ -73,8 +74,9 @@ import System.Win32.Types (withHandleToHANDLEPosix)
 
 #if !MIN_VERSION_Win32(2,5,0)
 import Foreign.C.Types (CShort (..))
+import Data.Word (Word32)
 #else
-import System.Win32.Types (SHORT)
+import System.Win32.Types (SHORT, ULONG)
 #endif
 
 #if !MIN_VERSION_Win32(2,5,1)
@@ -88,6 +90,7 @@ import GHC.IO.FD (FD(..)) -- A wrapper around an Int32
 
 #if !MIN_VERSION_Win32(2,5,0)
 type SHORT = CShort
+type ULONG = Word32
 #endif
 
 withStablePtr :: a -> (StablePtr a -> IO b) -> IO b

--- a/src/includes/Exports-Include.hs
+++ b/src/includes/Exports-Include.hs
@@ -105,6 +105,11 @@
   , useAlternateScreenBufferCode
   , useNormalScreenBufferCode
 
+    -- * Reporting the background or foreground colors
+  , reportLayerColor
+  , hReportLayerColor
+  , reportLayerColorCode
+
     -- * Select Graphic Rendition mode: colors and other whizzy stuff
   , setSGR
   , hSetSGR
@@ -155,3 +160,9 @@
     -- * Getting the terminal size
   , getTerminalSize
   , hGetTerminalSize
+
+    -- * Getting the background or foreground colors
+  , getLayerColor
+  , hGetLayerColor
+  , getReportedLayerColor
+  , layerColor


### PR DESCRIPTION
Also adds `hReportLayerColor`, `hGetLayerColor` and `layerColor`.

Not supported by terminals on Windows. Native terminals do not allow the color to be reported. Other terminals do not allow the reported color to be read from the console input stream.