### PR TITLE
Shave off mintty dependency if Win32 >= 2.13.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
           - "8.8.4"
           - "8.10.7"
         winio: [false]
+        win32-2_13_1: [false]
         include:
           - ghc: "9.0.2"
             cabal: "3.6"
@@ -72,6 +73,9 @@ jobs:
           - ghc: "9.2.2"
             cabal: "3.6"
             winio: true
+          - ghc: "9.4.2"
+            cabal: "3.6"
+            win32-2_13_1: true
     steps:
       - uses: actions/checkout@v2
       - uses: haskell/actions/setup@v2
@@ -92,3 +96,8 @@ jobs:
       - run: cabal v2-build
       - if: matrix.winio
         run: cabal v2-build --ghc-option=-with-rtsopts=--io-manager=native
+      - if: matrix.win32-2_13_1
+        run: |
+          # need to unfreeze Win32
+          rm cabal.project.freeze
+          cabal v2-build --constraint 'Win32 >= 2.13.1' --constraint 'ansi-terminal +Win32-2-13-1'

--- a/ansi-terminal.cabal
+++ b/ansi-terminal.cabal
@@ -29,6 +29,11 @@ Flag Example
         Description:    Build the example application
         Default:        False
 
+Flag Win32-2-13-1
+        Description:    Use Win32-2-13.1.0 or later. If used, there is
+                        no dependency on the mintty package.
+        Default:        True
+
 Library
         Hs-Source-Dirs:         src
         Exposed-Modules:        System.Console.ANSI
@@ -41,8 +46,10 @@ Library
                               , colour >=2.1.0
         if os(windows)
                 Build-Depends:          containers >= 0.5.0.0
-                                      , mintty
-                                      , Win32 >= 2.0
+                if flag(Win32-2-13-1)
+                      Build-Depends:   Win32 >= 2.13.1
+                else
+                      Build-Depends:   Win32 < 2.13.1, mintty
                 Cpp-Options:            -DWINDOWS
                 Other-Modules:          System.Console.ANSI.Windows
                                         System.Console.ANSI.Windows.Detect

--- a/src/System/Console/ANSI.hs
+++ b/src/System/Console/ANSI.hs
@@ -31,8 +31,9 @@ are flushed from the output buffer (with a newline character @\"\\n\"@ or, for
 the standard output channel, @hFlush stdout@).
 
 == \'ANSI\' standards
-The \'ANSI\' standards refer to (1) standard ECMA-48 \`Control Functions for
-Coded Character Sets\' (5th edition, 1991); (2) extensions in ITU-T
+The \'ANSI\' standards refer to (1) standard
+<https://www.ecma-international.org/wp-content/uploads/ECMA-48_5th_edition_june_1991.pdf ECMA-48>
+\`Control Functions for Coded Character Sets\' (5th edition, 1991); (2) extensions in ITU-T
 Recommendation (previously CCITT Recommendation) T.416 (03/93) \'Information
 Technology – Open Document Architecture (ODA) and Interchange Format: Character
 Content Architectures\` (also published as ISO/IEC International Standard

--- a/src/System/Console/ANSI/Windows/Detect.hs
+++ b/src/System/Console/ANSI/Windows/Detect.hs
@@ -15,7 +15,11 @@ import Control.Applicative ((<$>))
 
 import Control.Exception (SomeException(..), throwIO, try)
 import Data.Bits ((.&.), (.|.))
+#ifdef MIN_VERSION_mintty
 import System.Console.MinTTY (isMinTTYHandle)
+#else
+import System.Win32.MinTTY (isMinTTYHandle)
+#endif
 import System.IO (Handle, hIsWritable, stdout)
 import System.IO.Unsafe (unsafePerformIO)
 

--- a/src/System/Console/ANSI/Windows/Emulator.hs
+++ b/src/System/Console/ANSI/Windows/Emulator.hs
@@ -23,7 +23,11 @@ import Data.Colour (Colour)
 import Data.Colour.Names (black, blue, cyan, green, grey, lime, magenta, maroon,
   navy, olive, purple, red, silver, teal, white, yellow)
 import Data.Colour.SRGB (RGB (..), toSRGB)
+#ifdef MIN_VERSION_mintty
 import System.Console.MinTTY (isMinTTYHandle)
+#else
+import System.Win32.MinTTY (isMinTTYHandle)
+#endif
 
 import System.Console.ANSI.Types
 import qualified System.Console.ANSI.Unix as Unix

--- a/src/includes/Common-Include-Emulator.hs
+++ b/src/includes/Common-Include-Emulator.hs
@@ -47,16 +47,12 @@ clearFromCursorToLineEnd def = hClearFromCursorToLineEnd def stdout
 clearFromCursorToLineBeginning def = hClearFromCursorToLineBeginning def stdout
 clearLine def = hClearLine def stdout
 
--- | Scroll the displayed information up or down the terminal: not widely
--- supported
 hScrollPageUp, hScrollPageDown
   :: ConsoleDefaultState -- ^ The default console state
   -> Handle
   -> Int -- ^ Number of lines to scroll by
   -> IO ()
 
--- | Scroll the displayed information up or down the terminal: not widely
--- supported
 scrollPageUp, scrollPageDown
   :: ConsoleDefaultState -- ^ The default console state
   -> Int -- ^ Number of lines to scroll by

--- a/src/includes/Common-Include-Enabled.hs
+++ b/src/includes/Common-Include-Enabled.hs
@@ -40,15 +40,11 @@ clearFromCursorToLineEnd = hClearFromCursorToLineEnd stdout
 clearFromCursorToLineBeginning = hClearFromCursorToLineBeginning stdout
 clearLine = hClearLine stdout
 
--- Scroll the displayed information up or down the terminal: not widely
--- supported
 hScrollPageUp, hScrollPageDown
   :: Handle
   -> Int -- Number of lines to scroll by
   -> IO ()
 
--- | Scroll the displayed information up or down the terminal: not widely
--- supported
 scrollPageUp, scrollPageDown
   :: Int -- ^ Number of lines to scroll by
   -> IO ()

--- a/src/includes/Exports-Include.hs
+++ b/src/includes/Exports-Include.hs
@@ -6,6 +6,7 @@
     module System.Console.ANSI.Types
 
     -- * Cursor movement by character
+    -- | These code sequences are part of ECMA-48 standard and are portable.
   , cursorUp
   , cursorDown
   , cursorForward
@@ -27,8 +28,11 @@
     -- line, while functions like @cursorUp@ and @cursorDown@ keep the column
     -- the same.
     --
-    -- Also keep in mind that @*Line@ functions are not as portable. See
-    -- <https://github.com/UnkindPartition/ansi-terminal/issues/10> for the details.
+    -- These code sequences are part of ECMA-48 standard, but some obsolete terminals,
+    -- foremost <https://en.wikipedia.org/wiki/ANSI.SYS ANSI.SYS>, do not support them.
+    -- Replacing them by more fine-grained calls, e. g., @cursorUp n >> setCursorColumn 0@
+    -- instead of @cursorUpLine n@, does not help, because ANSI.SYS does not support
+    -- @setCursorColumn@ as well.
   , cursorUpLine
   , cursorDownLine
     -- ** \'h...\' variants
@@ -39,6 +43,9 @@
   , cursorDownLineCode
 
     -- * Directly changing cursor position
+    -- | These code sequences are part of ECMA-48 standard, but some obsolete terminals,
+    -- foremost <https://en.wikipedia.org/wiki/ANSI.SYS ANSI.SYS>, do not support
+    -- @setCursorColumn@. However, @setCursorPosition@ is supported even by ANSI.SYS.
   , setCursorColumn
   , setCursorPosition
     -- ** \'h...\' variants
@@ -49,6 +56,25 @@
   , setCursorPositionCode
 
     -- * Saving, restoring and reporting cursor position
+    -- | These code sequences are not part of ECMA-48 standard; they are popular,
+    -- but non-portable extensions. E. g., Terminal.app on MacOS
+    -- <https://stackoverflow.com/questions/25879183 does not support them>.
+    -- Somewhat surprisingly, ANSI.SYS does.
+    --
+    -- @terminfo@ package provides a portable way to determine correct sequences
+    -- for cursor positions:
+    --
+    -- >>> import System.Console.Terminfo
+    -- >>> t <- setupTermFromEnv
+    -- >>> getCapability t (tiGetOutput1 "sc") :: Maybe String -- save cursor position
+    -- Just "\ESC7"
+    -- >>> getCapability t (tiGetOutput1 "rc") :: Maybe String -- restore cursor position
+    -- Just "\ESC8"
+    --
+    -- On modern scrollable terminal emulators the semantics of cursor positions
+    -- is a bit unintuitive:
+    -- <https://unix.stackexchange.com/questions/565597 they are relative to the viewport, not to its content>.
+    --
   , saveCursor
   , restoreCursor
   , reportCursorPosition
@@ -65,6 +91,10 @@
     -- | Note that these functions only clear parts of the screen. They do not
     -- move the cursor. Some functions are based on the whole screen and others
     -- are based on the line in which the cursor is located.
+    --
+    -- These code sequences are part of ECMA-48 standard.
+    -- <https://web.archive.org/web/20171103053038/http://www.drdos.net:80/documentation/usergeng/09ugch9.htm#807 Some versions of ANSI.SYS>
+    -- support only @clearScreen@ and @clearFromCursorToLineEnd@, and some offer all variations.
   , clearFromCursorToScreenEnd
   , clearFromCursorToScreenBeginning
   , clearScreen
@@ -87,6 +117,8 @@
   , clearLineCode
 
     -- * Scrolling the screen
+    -- | Scroll the displayed information up or down the terminal.
+    -- These code sequences are part of ECMA-48 standard, but ANSI.SYS does not support them.
   , scrollPageUp
   , scrollPageDown
     -- ** \'h...\' variants
@@ -96,12 +128,15 @@
   , scrollPageUpCode
   , scrollPageDownCode
 
-    -- * Select Graphic Rendition mode: colors and other whizzy stuff
+    -- * Select Graphic Rendition mode: colors and other whizzy stuff.
+    -- | These code sequences are part of ECMA-48 standard and are portable.
   , setSGR
   , hSetSGR
   , setSGRCode
 
     -- * Cursor visibilty changes
+    -- | These code sequences are not part of ECMA-48 standard; they are popular,
+    -- but non-portable extensions. E. g., ANSI.SYS does not support them.
   , hideCursor
   , showCursor
     -- ** \'h...\' variants
@@ -112,8 +147,10 @@
   , showCursorCode
 
     -- * Hyperlinks
-    -- | Some, but not all, terminals support hyperlinks - that is, clickable
-    -- text that points to a URI. On Windows, if emulation is required,
+    -- | These code sequences are not part of ECMA-48 standard and not even an
+    -- @xterm@ extension. Nevertheless
+    -- <https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda many terminals>
+    -- support them. On Windows, if emulation is required,
     -- hyperlinks are not emulated.
   , hyperlink
   , hyperlinkWithId
@@ -128,6 +165,8 @@
   , hyperlinkWithParamsCode
 
     -- * Changing the title
+    -- | These code sequences are not part of ECMA-48 standard, but covered
+    -- by @xterm@ extensions. They are not very portable, especially on Windows.
   , setTitle
   , hSetTitle
   , setTitleCode


### PR DESCRIPTION
For sufficiently new Win32 the mintty library just re-exports `isMinTTYHandle` definition. In such case we'd rather skip building `mintty` dependency altogether. 

For a package like `ansi-terminal`, which is built so often, e. g., on every CI run, reducing number of dependecies is a worthy goal. 