### PR TITLE
Re #149 Introduce possiblity of parameter substrings

### DIFF
--- a/ansi-terminal/CHANGELOG.md
+++ b/ansi-terminal/CHANGELOG.md
@@ -1,6 +1,15 @@
 Changes
 =======
 
+Version 1.0.3
+-------------
+
+* Add type synonyms `Parameter`, `SubParam`, and `ParamWithSubs` to represent
+  SGR parameter values with and without following parameter substrings comprised
+  of one or more parameter elements (including empty elements).
+* Add `csi'` and `sgrToCode'`, corresponding to `csi` and `sgrToCode` but
+  capable of handling a parameter value followed by a parameter substring.
+
 Version 1.0.2
 -------------
 

--- a/ansi-terminal/ansi-terminal.cabal
+++ b/ansi-terminal/ansi-terminal.cabal
@@ -1,6 +1,6 @@
 Cabal-Version:       1.22
 Name:                ansi-terminal
-Version:             1.0.2
+Version:             1.0.3
 Category:            User Interfaces
 Synopsis:            Simple ANSI terminal support
 Description:         ANSI terminal support for Haskell: allows cursor movement,


### PR DESCRIPTION
Under 13.1.8 of T.416 (03/93), certain SGR parameter values can be followed by a parameter substring (also known as subparameters). T.416 used them for SGR parameter values 38 and 48, but they have also been put to use in the case of fancy and coloured underlining.