### PR TITLE
Fix #160 Add `hNowSupportsANSI`

### DIFF
--- a/ansi-terminal/CHANGELOG.md
+++ b/ansi-terminal/CHANGELOG.md
@@ -1,10 +1,30 @@
 Changes
 =======
 
+Version 1.0.1
+-------------
+
+* On Windows, the processing of \'ANSI\' control characters in output is enabled
+  by default in Windows Terminal but is not enabled by default in ConHost
+  terminals. Additions have been made to allow support of users of ConHost
+  terminals.
+* Add `hNowSupportsANSI`. On Unix, the function is equivalent to
+  `hSupportsANSI`. On Windows, in Windows Terminal and ConHost terminals, the
+  action can try to enable the processing of \'ANSI\' control characters in
+  output.
+* In Windows Terminal and ConHost terminals, `hSupportsANSI` will yield `False`
+  if the the processing of \'ANSI\' control characters in output is not enabled.
+* Deprecated `hSupportsANSIWithoutEmulation` is now consistent with
+  `hNowSupportsANSI`.
+* Improvements to Haddock documentation.
+
 Version 1.0
 -----------
 
-* On Windows, drop support for legacy Windows requiring emulation.
+* On Windows, drop support for legacy Windows requiring emulation. The package
+  assumes Windows Terminal has replaced ConHost terminals on supported versions
+  of Windows. Functions that yield actions no longer enable (re-enable) the
+  processing of \'ANSI\' control characters in output.
 * On Windows, the package no longer depends (directly or indirectly) on the
   `Win32`, `array`,`containers`, `deepseq`, `filepath`, `ghc-boot-th`, `mintty`,
   `pretty` or `template-haskell` packages.

--- a/ansi-terminal/ansi-terminal.cabal
+++ b/ansi-terminal/ansi-terminal.cabal
@@ -1,6 +1,6 @@
 Cabal-Version:       1.22
 Name:                ansi-terminal
-Version:             1.0
+Version:             1.0.1
 Category:            User Interfaces
 Synopsis:            Simple ANSI terminal support
 Description:         ANSI terminal support for Haskell: allows cursor movement,
@@ -16,6 +16,7 @@ Build-Type:          Simple
 Extra-Source-Files:     CHANGELOG.md
                         README.md
                         win/include/errors.h
+                        win/include/HsWin32.h
                         win/include/winternl_compat.h
 
 Source-repository head
@@ -47,8 +48,11 @@ Library
                                 System.Console.ANSI.Windows.Win32.MinTTY
             Include-Dirs:       win/include
             Includes:           errors.h
+                                HsWin32.h
                                 winternl_compat.h
+            Install-Includes:   HsWin32.h
             C-Sources:          win/c-source/errors.c
+                                win/c-source/HsWin32.c
         else
             Hs-Source-Dirs:     unix
 

--- a/ansi-terminal/app/Example.hs
+++ b/ansi-terminal/app/Example.hs
@@ -31,7 +31,13 @@ examples = [ cursorMovementExample
            ]
 
 main :: IO ()
-main = mapM_ (resetScreen >>) examples
+main = do
+  stdoutSupportsANSI <- hNowSupportsANSI stdout
+  if stdoutSupportsANSI
+    then
+      mapM_ (resetScreen >>) examples
+    else
+      putStrLn "Standard output does not support 'ANSI' escape codes."
 
 -- Annex D to Standard ECMA-48 (5th Ed, 1991) identifies that the representation
 -- of an erased state is implementation-dependent. There may or may not be a

--- a/ansi-terminal/unix/System/Console/ANSI/Internal.hs
+++ b/ansi-terminal/unix/System/Console/ANSI/Internal.hs
@@ -4,6 +4,7 @@ module System.Console.ANSI.Internal
   ( getReportedCursorPosition
   , getReportedLayerColor
   , hSupportsANSI
+  , hNowSupportsANSI
   ) where
 
 import Data.List ( uncons )
@@ -73,3 +74,6 @@ hSupportsANSI h = (&&) <$> hIsWritable h <*> hSupportsANSI'
  where
   hSupportsANSI' = (&&) <$> hIsTerminalDevice h <*> isNotDumb
   isNotDumb = (/= Just "dumb") <$> lookupEnv "TERM"
+
+hNowSupportsANSI :: Handle -> IO Bool
+hNowSupportsANSI = hSupportsANSI

--- a/ansi-terminal/win/System/Console/ANSI/Windows/Win32/Types.hs
+++ b/ansi-terminal/win/System/Console/ANSI/Windows/Win32/Types.hs
@@ -19,6 +19,7 @@ module System.Console.ANSI.Windows.Win32.Types
   , SHORT
   , TCHAR
   , UINT
+  , UINT_PTR
   , ULONG
   , USHORT
   , WCHAR
@@ -68,6 +69,7 @@ type LPWSTR = Ptr CWchar
 type SHORT = CShort
 type TCHAR = CWchar
 type UINT = Word32
+type UINT_PTR = Word
 type ULONG = Word32
 type USHORT = Word16
 type WCHAR = CWchar

--- a/ansi-terminal/win/c-source/HsWin32.c
+++ b/ansi-terminal/win/c-source/HsWin32.c
@@ -1,0 +1,3 @@
+// Out-of-line versions of all the inline functions from HsWin32.h
+#define INLINE  /* nothing */
+#include "HsWin32.h"

--- a/ansi-terminal/win/include/HsWin32.h
+++ b/ansi-terminal/win/include/HsWin32.h
@@ -1,0 +1,17 @@
+#ifndef __HSWIN32_H
+#define __HSWIN32_H
+
+#define UNICODE
+#include <windows.h>
+
+#ifndef INLINE
+# if defined(_MSC_VER)
+#  define INLINE extern __inline
+# else
+#  define INLINE extern inline
+# endif
+#endif
+
+INLINE void *castUINTPtrToPtr(UINT_PTR n) { return (void *)n; }
+
+#endif /* __HSWIN32_H */


### PR DESCRIPTION
* On Windows, the processing of \'ANSI\' control characters in output is enabled by default in Windows Terminal but is not enabled by default in ConHost terminals. Additions have been made to allow support of users of ConHost terminals.
* Add `hNowSupportsANSI`. On Unix, the function is equivalent to `hSupportsANSI`. On Windows, in Windows Terminal and ConHost terminals, the action can try to enable the processing of \'ANSI\' control characters in output. This is done without reintroducing a dependency on the `Win32` package.
* In Windows Terminal and ConHost terminals, `hSupportsANSI` will yield `False` if the the processing of \'ANSI\' control characters in output is not enabled. This is treated as a bug fix.
* Deprecated `hSupportsANSIWithoutEmulation` is now consistent with `hNowSupportsANSI`.
* Improvements to Haddock documentation.