### PR TITLE
Remove `includes:` field from Cabal file

### DIFF
--- a/ansi-terminal/ansi-terminal.cabal
+++ b/ansi-terminal/ansi-terminal.cabal
@@ -47,9 +47,6 @@ Library
                                 System.Console.ANSI.Windows.Win32.Types
                                 System.Console.ANSI.Windows.Win32.MinTTY
             Include-Dirs:       win/include
-            Includes:           errors.h
-                                HsWin32.h
-                                winternl_compat.h
             Install-Includes:   HsWin32.h
             C-Sources:          win/c-source/errors.c
                                 win/c-source/HsWin32.c


### PR DESCRIPTION
The `includes:` field has been ignored by GHC from GHC 6.10.1 and Cabal has not supported GHC versions before GHC 6.12 from Cabal 2.0.