### PR TITLE
Add disable and enable line wrap ANSI commands

### DIFF
--- a/ansi-terminal/src/System/Console/ANSI.hs
+++ b/ansi-terminal/src/System/Console/ANSI.hs
@@ -267,6 +267,16 @@ module System.Console.ANSI
   , clearFromCursorToLineBeginningCode
   , clearLineCode
 
+    -- * Enabling and disabling line wrap
+  , disableLineWrap
+  , enableLineWrap
+    -- ** \'h...\' variants
+  , hDisableLineWrap
+  , hEnableLineWrap
+    -- ** \'...Code\' variants
+  , disableLineWrapCode
+  , enableLineWrapCode
+
     -- * Scrolling the screen
   , scrollPageUp
   , scrollPageDown
@@ -1027,6 +1037,16 @@ clearFromCursorToLineEnd, clearFromCursorToLineBeginning, clearLine :: IO ()
 clearFromCursorToLineEnd = hClearFromCursorToLineEnd stdout
 clearFromCursorToLineBeginning = hClearFromCursorToLineBeginning stdout
 clearLine = hClearLine stdout
+
+hEnableLineWrap, hDisableLineWrap ::
+     Handle
+  -> IO ()
+hEnableLineWrap h = hPutStr h enableLineWrapCode
+hDisableLineWrap h = hPutStr h disableLineWrapCode
+
+enableLineWrap, disableLineWrap :: IO ()
+enableLineWrap = hEnableLineWrap stdout
+disableLineWrap = hDisableLineWrap stdout
 
 hScrollPageUp, hScrollPageDown ::
      Handle

--- a/ansi-terminal/src/System/Console/ANSI/Codes.hs
+++ b/ansi-terminal/src/System/Console/ANSI/Codes.hs
@@ -35,6 +35,9 @@ module System.Console.ANSI.Codes
   , clearScreenCode, clearFromCursorToLineEndCode
   , clearFromCursorToLineBeginningCode, clearLineCode
 
+    -- * Enabling and disabling line wrap
+  , enableLineWrapCode, disableLineWrapCode
+
     -- * Scrolling the screen
     --
     -- | These functions yield @\"\"@ when the number is @0@ as, on some
@@ -308,6 +311,10 @@ clearScreenCode = csi [2] "J"
 clearFromCursorToLineEndCode = csi [0] "K"
 clearFromCursorToLineBeginningCode = csi [1] "K"
 clearLineCode = csi [2] "K"
+
+enableLineWrapCode, disableLineWrapCode :: String
+enableLineWrapCode = csi [] "?7h"
+disableLineWrapCode = csi [] "?7l"
 
 scrollPageUpCode, scrollPageDownCode ::
      Int -- ^ Number of lines to scroll by


### PR DESCRIPTION
These are very useful for ensuring that the `clearLine` command works consistently, by avoiding wrapped lines. Technically they appear to be nonstandard, but they are used in quite a bit of software.