### PR TITLE
Switch to using `Win32` for obtaining Windows handles

### DIFF
--- a/ansi-terminal/ansi-terminal.cabal
+++ b/ansi-terminal/ansi-terminal.cabal
@@ -46,6 +46,7 @@ Library
             Other-Modules:      System.Console.ANSI.Windows.Foreign
                                 System.Console.ANSI.Windows.Win32.Types
                                 System.Console.ANSI.Windows.Win32.MinTTY
+            Build-Depends:      Win32 >= 2.14
             Include-Dirs:       win/include
             Install-Includes:   HsWin32.h
             C-Sources:          win/c-source/errors.c


### PR DESCRIPTION
There is an effort to move some GHC-specific modules out of `base`. A candidate for such moving is `GHC.IO.Handle.Types`. This module is often used for obtaining operating-system handles (file descriptors, Windows handles) from Haskell handles. Such a use is also present in the `ansi-terminal` package: in the implementation of the internal operation `System.Console.ANSI.Windows.Win32.Types.withHandleToHANDLE`. However, this implementation was copied into the `Win32` package already for its version 2.5.1, so that now `ansi-terminal` does not need its own implementation of Windows handle acquisition anymore.

This pull request removes the implementation of `withHandleToHANDLE` from `System.Console.ANSI.Windows.Win32.Types` and lets this module re-export `withHandleToHANDLE` from `Win32` instead.

I suggest to check, as a follow-up project, whether `System.Console.ANSI.Windows.Win32.Types` is needed at all these days, given that the module `System.Win32.Types` from `Win32` seems to provide pretty much the same things.