### PR TITLE
Fix #185 Don't depend on GHC.IO.* from base, from GHC 9.10

### DIFF
--- a/ansi-terminal/ansi-terminal.cabal
+++ b/ansi-terminal/ansi-terminal.cabal
@@ -41,6 +41,8 @@ Library
         Build-Depends:          base >= 4.8.0.0 && < 5
                               , ansi-terminal-types == 1.1.3
                               , colour >= 2.1.0
+        if impl(ghc >= 9.10)
+            Build-Depends:      ghc-internal >= 9.1001.0
         if os(windows)
             Hs-Source-Dirs:     win
             Other-Modules:      System.Console.ANSI.Windows.Foreign

--- a/ansi-terminal/stack.yaml
+++ b/ansi-terminal/stack.yaml
@@ -1,4 +1,4 @@
-snapshot: lts-24.0 # GHC 9.10.2
+snapshot: lts-24.10 # GHC 9.10.2
 flags:
   ansi-terminal:
     example: false

--- a/ansi-terminal/win/System/Console/ANSI/Windows/Win32/Types.hs
+++ b/ansi-terminal/win/System/Console/ANSI/Windows/Win32/Types.hs
@@ -41,16 +41,28 @@ import Foreign.C.String ( peekCWString )
 import Foreign.C.Types ( CChar, CInt (..), CShort (..), CWchar )
 import Foreign.Ptr ( Ptr, nullPtr )
 import Foreign.StablePtr ( StablePtr, freeStablePtr, newStablePtr )
+#if MIN_VERSION_base(4,20,0)
+import GHC.Internal.IO.Handle.Types ( Handle (..), Handle__ (..) )
+import GHC.Internal.IO.FD ( FD(..) ) -- A wrapper around an Int32
+#else
 import GHC.IO.Handle.Types ( Handle (..), Handle__ (..) )
 import GHC.IO.FD ( FD(..) ) -- A wrapper around an Int32
+#endif
 import Numeric ( showHex )
 import System.IO.Error ( ioeSetErrorString )
 
 #if defined(__IO_MANAGER_WINIO__)
+#if MIN_VERSION_base(4,20,0)
+import GHC.Internal.IO.Exception
+         ( IOErrorType (InappropriateType), IOException (IOError), ioException )
+import GHC.Internal.IO.SubSystem ( (<!>) )
+import GHC.Internal.IO.Windows.Handle ( ConsoleHandle, Io, NativeHandle, toHANDLE )
+#else
 import GHC.IO.Exception
          ( IOErrorType (InappropriateType), IOException (IOError), ioException )
 import GHC.IO.SubSystem ( (<!>) )
 import GHC.IO.Windows.Handle ( ConsoleHandle, Io, NativeHandle, toHANDLE )
+#endif
 #endif
 
 type Addr = Ptr ()


### PR DESCRIPTION
See:
* #185 

We don't want to depend on `Win32`, but we can skip `base` and depend on `ghc-internal` directly.