### PR TITLE
Switch to the new operations for obtaining OS handles

### DIFF
--- a/ansi-terminal/ansi-terminal.cabal
+++ b/ansi-terminal/ansi-terminal.cabal
@@ -41,8 +41,6 @@ Library
         Build-Depends:          base >= 4.8.0.0 && < 5
                               , ansi-terminal-types == 1.1.3
                               , colour >= 2.1.0
-        if impl(ghc >= 9.10)
-            Build-Depends:      ghc-internal >= 9.1001.0
         if os(windows)
             Hs-Source-Dirs:     win
             Other-Modules:      System.Console.ANSI.Windows.Foreign

--- a/ansi-terminal/stack.yaml
+++ b/ansi-terminal/stack.yaml
@@ -1,4 +1,4 @@
-snapshot: lts-24.10 # GHC 9.10.2
+snapshot: lts-24.0 # GHC 9.10.2
 flags:
   ansi-terminal:
     example: false

--- a/ansi-terminal/win/System/Console/ANSI/Windows/Win32/Types.hs
+++ b/ansi-terminal/win/System/Console/ANSI/Windows/Win32/Types.hs
@@ -41,28 +41,16 @@ import Foreign.C.String ( peekCWString )
 import Foreign.C.Types ( CChar, CInt (..), CShort (..), CWchar )
 import Foreign.Ptr ( Ptr, nullPtr )
 import Foreign.StablePtr ( StablePtr, freeStablePtr, newStablePtr )
-#if MIN_VERSION_base(4,20,0)
-import GHC.Internal.IO.Handle.Types ( Handle (..), Handle__ (..) )
-import GHC.Internal.IO.FD ( FD(..) ) -- A wrapper around an Int32
-#else
 import GHC.IO.Handle.Types ( Handle (..), Handle__ (..) )
 import GHC.IO.FD ( FD(..) ) -- A wrapper around an Int32
-#endif
 import Numeric ( showHex )
 import System.IO.Error ( ioeSetErrorString )
 
 #if defined(__IO_MANAGER_WINIO__)
-#if MIN_VERSION_base(4,20,0)
-import GHC.Internal.IO.Exception
-         ( IOErrorType (InappropriateType), IOException (IOError), ioException )
-import GHC.Internal.IO.SubSystem ( (<!>) )
-import GHC.Internal.IO.Windows.Handle ( ConsoleHandle, Io, NativeHandle, toHANDLE )
-#else
 import GHC.IO.Exception
          ( IOErrorType (InappropriateType), IOException (IOError), ioException )
 import GHC.IO.SubSystem ( (<!>) )
 import GHC.IO.Windows.Handle ( ConsoleHandle, Io, NativeHandle, toHANDLE )
-#endif
 #endif
 
 type Addr = Ptr ()

--- a/ansi-terminal/win/System/Console/ANSI/Windows/Win32/Types.hs
+++ b/ansi-terminal/win/System/Console/ANSI/Windows/Win32/Types.hs
@@ -30,27 +30,47 @@ module System.Console.ANSI.Windows.Win32.Types
   , withHandleToHANDLE
   ) where
 
-import Control.Concurrent.MVar ( readMVar )
-import Control.Exception ( bracket, throwIO )
+import Control.Exception ( throwIO )
 import Control.Monad ( when )
 import Data.Char ( isSpace )
-import Data.Typeable ( cast )
 import Data.Word ( Word16, Word32 )
 import Foreign.C.Error ( Errno (..), errnoToIOError )
 import Foreign.C.String ( peekCWString )
 import Foreign.C.Types ( CChar, CInt (..), CShort (..), CWchar )
 import Foreign.Ptr ( Ptr, nullPtr )
-import Foreign.StablePtr ( StablePtr, freeStablePtr, newStablePtr )
-import GHC.IO.Handle.Types ( Handle (..), Handle__ (..) )
-import GHC.IO.FD ( FD(..) ) -- A wrapper around an Int32
 import Numeric ( showHex )
 import System.IO.Error ( ioeSetErrorString )
 
+#if __GLASGOW_HASKELL__ >= 915
+
+import System.IO ( Handle )
+import System.IO.OS ( withFileDescriptorWritingBiasedRaw )
+
 #if defined(__IO_MANAGER_WINIO__)
+
+import GHC.IO.SubSystem ( (<!>) )
+import System.IO.OS ( withWindowsHandleWritingBiasedRaw )
+
+#endif
+
+#else
+
+import Control.Concurrent.MVar ( readMVar )
+import Control.Exception ( bracket )
+import Data.Typeable ( cast )
+import Foreign.StablePtr ( StablePtr, freeStablePtr, newStablePtr )
+import GHC.IO.Handle.Types ( Handle (..), Handle__ (..) )
+import GHC.IO.FD ( FD(..) ) -- A wrapper around an Int32
+
+#if defined(__IO_MANAGER_WINIO__)
+
+import GHC.IO.SubSystem ( (<!>) )
 import GHC.IO.Exception
          ( IOErrorType (InappropriateType), IOException (IOError), ioException )
-import GHC.IO.SubSystem ( (<!>) )
 import GHC.IO.Windows.Handle ( ConsoleHandle, Io, NativeHandle, toHANDLE )
+
+#endif
+
 #endif
 
 type Addr = Ptr ()
@@ -74,6 +94,35 @@ type ULONG = Word32
 type USHORT = Word16
 type WCHAR = CWchar
 type WORD = Word16
+
+#if __GLASGOW_HASKELL__ >= 915
+
+#if defined(__IO_MANAGER_WINIO__)
+
+{-
+    Note that this implementation of 'withHandleToHANDLE' differs from the one
+    provided by the @Win32@ package in that it partly or fully blocks operations
+    on the given Haskell handle during the execution of the user-provided
+    action, to an extend that interaction with the Windows handle through the
+    Haskell handle is prevented.
+-}
+withHandleToHANDLE :: Handle -> (HANDLE -> IO a) -> IO a
+withHandleToHANDLE = withHandleToHANDLEPOSIX
+                     <!>
+                     withWindowsHandleWritingBiasedRaw
+
+#else
+
+withHandleToHANDLE :: Handle -> (HANDLE -> IO a) -> IO a
+withHandleToHANDLE = withHandleToHANDLEPOSIX
+
+#endif
+
+withHandleToHANDLEPOSIX :: Handle -> (HANDLE -> IO a) -> IO a
+withHandleToHANDLEPOSIX h act = withFileDescriptorWritingBiasedRaw h $
+                                act . c_get_osfhandle
+
+#else
 
 withStablePtr :: a -> (StablePtr a -> IO b) -> IO b
 withStablePtr value = bracket (newStablePtr value) freeStablePtr
@@ -130,6 +179,8 @@ withHandleToHANDLEPosix haskell_handle action =
     windows_handle <- c_get_osfhandle fd
     -- Do what the user originally wanted
     action windows_handle
+
+#endif
 
 -- This essential function comes from the C runtime system. It is certainly
 -- provided by msvcrt, and also seems to be provided by the mingw C library -


### PR DESCRIPTION
This is another attempt to solve the problem described in #185, one that neither introduces a dependency on `Win32`, as #185 does, nor on `ghc-internal`, as #186 does. This pull request introduces an alternative implementation of `withHandleToHANDLE`, which uses the new operations for obtaining operating-system handles that are provided by GHC merge request [!14732](https://gitlab.haskell.org/ghc/ghc/-/merge_requests/14732). For converting from file descriptors to Windows handles, it continues to use the C function `_get_osfhandle` directly.

Please note the following:

* This pull request reverts the changes introduced by #186, because it follows an entirely different route.
* The alternative implementation of `withHandleToHANDLE` that this pull request introduces is only used when compiling with GHC 9.15 or later.
* It is hoped that the new operations provivded by GHC merge request [!14732](https://gitlab.haskell.org/ghc/ghc/-/merge_requests/14732) will be shipped with GHC 9.16. However, this is not guaranteed, which is why this pull request is marked as a draft at the moment.
* The behavior of the alternative implementation of `withHandleToHANDLE` differs from the behavior of the traditional implementation in that it fully blocks operations on the given Haskell handle during the execution of the user-provided action, to an extend that interaction with the Windows handle through the Haskell handle is prevented. It should be checked whether this can cause problems in `ansi-terminal`. Maybe it will even prevent race conditions.