### PR TITLE
Re #186 Revert "Fix #185 Don't depend on GHC.IO.* from base, from GHC 9.10"

### DIFF
--- a/ansi-terminal/ansi-terminal.cabal
+++ b/ansi-terminal/ansi-terminal.cabal
@@ -41,8 +41,6 @@ Library
         Build-Depends:          base >= 4.8.0.0 && < 5
                               , ansi-terminal-types == 1.1.3
                               , colour >= 2.1.0
-        if impl(ghc >= 9.10)
-            Build-Depends:      ghc-internal >= 9.1001.0
         if os(windows)
             Hs-Source-Dirs:     win
             Other-Modules:      System.Console.ANSI.Windows.Foreign

--- a/ansi-terminal/win/System/Console/ANSI/Windows/Win32/Types.hs
+++ b/ansi-terminal/win/System/Console/ANSI/Windows/Win32/Types.hs
@@ -41,28 +41,16 @@ import Foreign.C.String ( peekCWString )
 import Foreign.C.Types ( CChar, CInt (..), CShort (..), CWchar )
 import Foreign.Ptr ( Ptr, nullPtr )
 import Foreign.StablePtr ( StablePtr, freeStablePtr, newStablePtr )
-#if MIN_VERSION_base(4,20,0)
-import GHC.Internal.IO.Handle.Types ( Handle (..), Handle__ (..) )
-import GHC.Internal.IO.FD ( FD(..) ) -- A wrapper around an Int32
-#else
 import GHC.IO.Handle.Types ( Handle (..), Handle__ (..) )
 import GHC.IO.FD ( FD(..) ) -- A wrapper around an Int32
-#endif
 import Numeric ( showHex )
 import System.IO.Error ( ioeSetErrorString )
 
 #if defined(__IO_MANAGER_WINIO__)
-#if MIN_VERSION_base(4,20,0)
-import GHC.Internal.IO.Exception
-         ( IOErrorType (InappropriateType), IOException (IOError), ioException )
-import GHC.Internal.IO.SubSystem ( (<!>) )
-import GHC.Internal.IO.Windows.Handle ( ConsoleHandle, Io, NativeHandle, toHANDLE )
-#else
 import GHC.IO.Exception
          ( IOErrorType (InappropriateType), IOException (IOError), ioException )
 import GHC.IO.SubSystem ( (<!>) )
 import GHC.IO.Windows.Handle ( ConsoleHandle, Io, NativeHandle, toHANDLE )
-#endif
 #endif
 
 type Addr = Ptr ()


### PR DESCRIPTION
See:
* #185 
* #186

This reverts commit 40f912405c9e616d22a638cb3f2ea33b085180dd.